### PR TITLE
add: gmod-integration as whitelist domains

### DIFF
--- a/lua/nova/modules/config/defaultsettings.lua
+++ b/lua/nova/modules/config/defaultsettings.lua
@@ -113,7 +113,7 @@ Nova.setSetting("networking_http_whitelistdomains", {
 	"google.com",
 	"vcmod.org",
 	"m4dsolutions.com",
-	"gmod-integration.com",
+	"api.gmod-integration.com",
 }, true, true, nil, true)
 
 Nova.setSetting("networking_fetch_overwrite", false, true, true)

--- a/lua/nova/modules/config/defaultsettings.lua
+++ b/lua/nova/modules/config/defaultsettings.lua
@@ -113,6 +113,7 @@ Nova.setSetting("networking_http_whitelistdomains", {
 	"google.com",
 	"vcmod.org",
 	"m4dsolutions.com",
+	"gmod-integration.com",
 }, true, true, nil, true)
 
 Nova.setSetting("networking_fetch_overwrite", false, true, true)


### PR DESCRIPTION
Hello,

I'm the owner of Gmod Integration, a service tailored for Discord communities that operate Gmod servers. Our service offers features like chat relay, role synchronization, pseudo synchronization, and admin sanction synchronization ...

We're proud to support over 35,500 users and more than 250 servers.

Our Gmod content is open source and available on GitHub: [Gmod Integration Glua](https://github.com/gmod-integration/glua).

Please consider accepting this pull request as soon as possible.

Thank you,
Grégoire Launay-Bécue (Linventif)

[Website](https://gmod-integration.com)
[Discord](https://gmod-integration.com/discord)
[Github](https://github.com/gmod-integration)