### PR TITLE
Set default decompression limit to 100 MB

### DIFF
--- a/lua/nova/modules/config/defaultsettings.lua
+++ b/lua/nova/modules/config/defaultsettings.lua
@@ -65,7 +65,7 @@ Nova.setSetting("networking_dos_checkinterval", 5, false, true)
 Nova.setSetting("networking_dos_crash_enabled", true, true, true)
 Nova.setSetting("networking_dos_crash_action", "ask", true, true, {"kick", "ban", "notify", "ask", "nothing"})
 Nova.setSetting("networking_dos_crash_ignoreprotected", true, true, true, nil, true)
-Nova.setSetting("networking_dos_crash_maxsize", 200, true, true, nil, true)
+Nova.setSetting("networking_dos_crash_maxsize", 100, true, true, nil, true)
 Nova.setSetting("networking_dos_crash_ratio", 500, true, true, nil, true)
 Nova.setSetting("networking_dos_crash_whitelist", {}, true, true, nil, true)
 

--- a/lua/nova/modules/custom/versions.lua
+++ b/lua/nova/modules/custom/versions.lua
@@ -52,6 +52,13 @@ local patches = {
             Nova.log("i", "Disabling 'ban' action for fingerprint bypass")
             Nova.setSetting("banbypass_bypass_fingerprint_action", "ask")
         end
+    end,
+    ["1.10.5"] = function()
+        local cur = Nova.getSetting("networking_dos_crash_maxsize", 0)
+        // adjust default to 100 MB as there exists no good usecase for 200 MB
+        if cur == 200 then
+            Nova.setSetting("networking_dos_crash_maxsize", 100)
+        end
     end
 }
 


### PR DESCRIPTION
According to some server owners this fixes server crashes. 200 MB was initially too high.