### PR TITLE
Fix error when player is being inspected by two admins

### DIFF
--- a/lua/nova/modules/admin/inspection.lua
+++ b/lua/nova/modules/admin/inspection.lua
@@ -305,6 +305,11 @@ local function OpenSession(adminSteamID, clientSteamID)
         return false, "notify_admin_already_inspecting"
     end
 
+    // check if client is already being inspected by another admin
+    if clientSessionLookup[clientSteamID] then
+        return false, "notify_admin_client_already_inspected"
+    end
+
     local client = Nova.fPlayerBySteamID(clientSteamID)
     local admin = Nova.fPlayerBySteamID(adminSteamID)
 

--- a/lua/nova/modules/language/de.lua
+++ b/lua/nova/modules/language/de.lua
@@ -222,6 +222,7 @@ local phrases = {
     ["notify_admin_no_permission"] = "Du bist hierzu nicht berechtigt",
     ["notify_admin_client_not_connected"] = "Spieler ist offline",
     ["notify_admin_already_inspecting"] = "Du untersuchst bereits einen anderen Spieler",
+    ["notify_admin_client_already_inspected"] = "Dieser Spieler wird bereits von einem anderen Admin untersucht",
 
     ["notify_anticheat_detection"] = "Anticheat Erkennung %q bei %s. Grund: %q",
     ["notify_anticheat_detection_action"] = "Anticheat: %q",

--- a/lua/nova/modules/language/en.lua
+++ b/lua/nova/modules/language/en.lua
@@ -222,6 +222,7 @@ local phrases = {
     ["notify_admin_no_permission"] = "You do not have sufficient right to do that",
     ["notify_admin_client_not_connected"] = "Player is offline",
     ["notify_admin_already_inspecting"] = "You are already inspecting another player",
+    ["notify_admin_client_already_inspected"] = "This player is already being inspected by another admin",
 
     ["notify_anticheat_detection"] = "Anticheat detection %q on %s. Reason: %q",
     ["notify_anticheat_detection_action"] = "Anticheat: %q",

--- a/lua/nova/modules/language/fr.lua
+++ b/lua/nova/modules/language/fr.lua
@@ -222,6 +222,7 @@ local phrases = {
     ["notify_admin_no_permission"] = "Vous n'avez pas les permissions suffisantes pour faire cela",
     ["notify_admin_client_not_connected"] = "Le joueur est hors ligne",
     ["notify_admin_already_inspecting"] = "Vous inspectez déjà un autre joueur",
+    ["notify_admin_client_already_inspected"] = "Ce joueur est déjà inspecté par un autre administrateur",
 
     ["notify_anticheat_detection"] = "Détection anticheat %q sur %s. Raison: %q",
     ["notify_anticheat_detection_action"] = "Anticheat: %q",

--- a/lua/nova/modules/language/ru.lua
+++ b/lua/nova/modules/language/ru.lua
@@ -223,6 +223,7 @@ local phrases = {
     ["notify_admin_no_permission"] = "У вас нет достаточного права делать это",
     ["notify_admin_client_not_connected"] = "Игрок не на сервере",
     ["notify_admin_already_inspecting"] = "Вы уже проверяете другого игрока",
+    ["notify_admin_client_already_inspected"] = "Этот игрок уже проверяется другим администратором",
 
     ["notify_anticheat_detection"] = "Обнаружение античита %q - %s. Причина: %q",
     ["notify_anticheat_detection_action"] = "Античит: %q",

--- a/lua/nova/modules/language/zh_hans.lua
+++ b/lua/nova/modules/language/zh_hans.lua
@@ -206,6 +206,7 @@ local phrases = {
     ["notify_admin_no_permission"] = "您没有足够的权限执行该操作",
     ["notify_admin_client_not_connected"] = "玩家离线",
     ["notify_admin_already_inspecting"] = "您已经在检查另一位玩家了",
+    ["notify_admin_client_already_inspected"] = "该玩家已被另一位管理员检查中",
 
     ["notify_anticheat_detection"] = "反作弊检测 %q 在 %s。原因：%q",
     ["notify_anticheat_detection_action"] = "反作弊：%q",


### PR DESCRIPTION
False detections are triggered when two admins are inspecting one player. Closing the session will make it invalid for the other admin also. An error will now be thrown, to prevent this.